### PR TITLE
Smooth cursor animation (macOS)

### DIFF
--- a/src/nsterm.h
+++ b/src/nsterm.h
@@ -485,6 +485,7 @@ enum ns_return_frame_mode
   struct frame *emacsframe;
   int scrollbarsNeedingUpdate;
   NSRect ns_userRect;
+  CALayer *cursor_layer;
 }
 
 /* AppKit-side interface */

--- a/src/nsterm.m
+++ b/src/nsterm.m
@@ -71,6 +71,7 @@ GNUstep port and post-20 update by Adrian Robert (arobert@cogsci.ucsd.edu)
 #include "macfont.h"
 #include <Carbon/Carbon.h>
 #include <IOSurface/IOSurface.h>
+#include <QuartzCore/QuartzCore.h>
 #endif
 
 static EmacsMenu *dockMenu;
@@ -3064,6 +3065,9 @@ ns_draw_window_cursor (struct window *w, struct glyph_row *glyph_row,
       return;
     }
 
+  if (!active_p)
+    return;
+
   get_phys_cursor_geometry (w, glyph_row, phys_cursor_glyph, &fx, &fy, &h);
 
   /* The above get_phys_cursor_geometry call set w->phys_cursor_width
@@ -3101,44 +3105,23 @@ ns_draw_window_cursor (struct window *w, struct glyph_row *glyph_row,
   /* Prevent the cursor from being drawn outside the text area.  */
   r = NSIntersectionRect (r, ns_row_rect (w, glyph_row, TEXT_AREA));
 
-  ns_focus (f, NULL, 0);
-
-  NSGraphicsContext *ctx = [NSGraphicsContext currentContext];
-  [ctx saveGraphicsState];
-#ifdef NS_IMPL_GNUSTEP
-  GSRectClipList (ctx, &r, 1);
-#else
-  NSRectClip (r);
-#endif
-
-  [FRAME_CURSOR_COLOR (f) set];
-
-  switch (cursor_type)
+  /* the CA cursor doesn't need a drawing context: we directly set its color. */
+  EmacsView *view = FRAME_NS_VIEW (f);
+  CALayer *cursor_layer = view->cursor_layer;
+  if (! cursor_layer)
+    return;
+  r.origin.y = [view bounds].size.height - r.size.height - r.origin.y;
+  [CATransaction begin];
+  [CATransaction setAnimationDuration:0.1];
+  cursor_layer.backgroundColor = FRAME_CURSOR_COLOR (f).CGColor;
+  if (cursor_type == BAR_CURSOR)
     {
-    case DEFAULT_CURSOR:
-    case NO_CURSOR:
-      break;
-    case FILLED_BOX_CURSOR:
-      /* The call to draw_phys_cursor_glyph can end up undoing the
-	 ns_focus, so unfocus here and regain focus later.  */
-      [ctx restoreGraphicsState];
-      ns_unfocus (f);
-      draw_phys_cursor_glyph (w, glyph_row, DRAW_CURSOR);
-      ns_focus (f, &r, 1);
-      break;
-    case HOLLOW_BOX_CURSOR:
-      /* This works like it does in PostScript, not X Windows.  */
-      [NSBezierPath strokeRect: NSInsetRect (r, 0.5, 0.5)];
-      [ctx restoreGraphicsState];
-      break;
-    case HBAR_CURSOR:
-    case BAR_CURSOR:
-      NSRectFill (r);
-      [ctx restoreGraphicsState];
-      break;
+      cursor_glyph = get_phys_cursor_glyph (w);
+      if ((cursor_glyph->resolved_level & 1) != 0)
+        r.origin.x += cursor_glyph->pixel_width - r.size.width;
     }
-
-  ns_unfocus (f);
+  cursor_layer.frame = r;
+  [CATransaction commit];
 }
 
 
@@ -9233,6 +9216,17 @@ ns_in_echo_area (void)
       [self setDelegate:view];
       [[self contentView] addSubview:view];
       [self makeFirstResponder:view];
+
+      /* Overlay a canvas view on top of EmacsView.  */
+      NSView *canvasView = [[NSView alloc] initWithFrame:view.bounds];
+      canvasView.wantsLayer = YES;
+      canvasView.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
+      [view addSubview:canvasView positioned:NSWindowAbove relativeTo:nil];
+
+      /* Create a cursor layer on the canvas.  */
+      view->cursor_layer = [CALayer layer];
+      [canvasView.layer addSublayer: view->cursor_layer];
+      view->cursor_layer.frame = CGRectMake(0, 0, 0, 0);
 
 #if !defined (NS_IMPL_COCOA) || MAC_OS_X_VERSION_MIN_REQUIRED <= 1090
 #if MAC_OS_X_VERSION_MAX_ALLOWED > 1090


### PR DESCRIPTION
# What is it?

This implements a smooth transitional animation for cursor movement. Sorta similar to recent versions of MS Word. I also believe it will be not hard to be extended to behave like Neovide's morphing cursors, which is the direct inspiration for this patch.

https://github.com/user-attachments/assets/8ead0726-a5b2-45b4-882c-57f868d36cc2

A nice thing is that the cursor can also move (or fly) between windows. It's cool and satisfying.


https://github.com/user-attachments/assets/22757448-1a55-4b1d-b785-2ec179eab63e



# How is it implemented?

Using the macOS-only CoreAnimation framework.

Unfortunately, it's difficult to implement for Linux Emacs because there seems to be no obvious animation framework choice like CoreAnimation. And it seems not worth the effort to implement animation logic in Emacs itself.

Without a proper Linux implementation, this feature would never be accepted by the upstream.

# Known issues

Please understand this is essentially a proof-of-concept. It's unfinished work. It could be improved greatly but I never took the time to do so. Use at your own risk.

1. The 'box' cursor will cover the glyph below the cursor. This is especially bad for images. You probably need to switch to 'bar' to use this patch. A workaround is to make the cursor layer transparent.
2. ~~blink-cursor-mode doesn't work.~~
3. ~~Not really configurablle: You cannot use the old cursor if you build Emacs with this patch. Also, the animation duration is hard-coded.~~

These issues are not hard to solve. But it's been working nicely for three months for me, so I'll publish it anyway. Maybe someone will like it and pick it up, or maybe I will work on it later.

**edit**: Some of these are addressed by #9 . Thanks!