### PR TITLE
Add smooth cursor animation for more cursor styles

### DIFF
--- a/lisp/term/ns-win.el
+++ b/lisp/term/ns-win.el
@@ -65,6 +65,13 @@
 ;; nsterm.m.
 (defvar ns-input-file)
 
+(defcustom ns-cursor-animation-duration 0.1
+  "Duration in seconds for cursor animation on macOS.
+This controls how long the cursor animation takes when changing position or style.
+A value of 0 disables animation."
+  :type 'number
+  :group 'ns)
+
 (defun ns-handle-nxopen (_switch &optional temp)
   (setq unread-command-events (append unread-command-events
                                       (if temp '(ns-open-temp-file)

--- a/src/nsterm.m
+++ b/src/nsterm.m
@@ -44,6 +44,7 @@ GNUstep port and post-20 update by Adrian Robert (arobert@cogsci.ucsd.edu)
 
 #include "lisp.h"
 #include "blockinput.h"
+#include "dispextern.h"
 #include "sysselect.h"
 #include "nsterm.h"
 #include "systime.h"
@@ -3017,6 +3018,12 @@ ns_draw_fringe_bitmap (struct window *w, struct glyph_row *row,
   ns_unfocus (f);
 }
 
+static double
+ns_get_cursor_animation_duration (void)
+{
+  Lisp_Object duration = Fsymbol_value (intern_c_string ("ns-cursor-animation-duration"));
+  return NUMBERP (duration) ? XFLOATINT (duration) : 0.1;
+}
 
 static void
 ns_draw_window_cursor (struct window *w, struct glyph_row *glyph_row,
@@ -3065,9 +3072,6 @@ ns_draw_window_cursor (struct window *w, struct glyph_row *glyph_row,
       return;
     }
 
-  if (!active_p)
-    return;
-
   get_phys_cursor_geometry (w, glyph_row, phys_cursor_glyph, &fx, &fy, &h);
 
   /* The above get_phys_cursor_geometry call set w->phys_cursor_width
@@ -3105,23 +3109,84 @@ ns_draw_window_cursor (struct window *w, struct glyph_row *glyph_row,
   /* Prevent the cursor from being drawn outside the text area.  */
   r = NSIntersectionRect (r, ns_row_rect (w, glyph_row, TEXT_AREA));
 
-  /* the CA cursor doesn't need a drawing context: we directly set its color. */
+  /* The original Emacs uses the following ctx-related stuff to draw
+     the cursor. Here we use the CA layer directly if possible. */
   EmacsView *view = FRAME_NS_VIEW (f);
   CALayer *cursor_layer = view->cursor_layer;
-  if (! cursor_layer)
-    return;
-  r.origin.y = [view bounds].size.height - r.size.height - r.origin.y;
-  [CATransaction begin];
-  [CATransaction setAnimationDuration:0.1];
-  cursor_layer.backgroundColor = FRAME_CURSOR_COLOR (f).CGColor;
-  if (cursor_type == BAR_CURSOR)
-    {
-      cursor_glyph = get_phys_cursor_glyph (w);
-      if ((cursor_glyph->resolved_level & 1) != 0)
-        r.origin.x += cursor_glyph->pixel_width - r.size.width;
+
+  if (active_p && cursor_layer) {
+    NSRect r2 = r;
+    r2.origin.y = [view bounds].size.height - r2.size.height - r2.origin.y;
+    cursor_glyph = get_phys_cursor_glyph (w);
+    if ((cursor_glyph->resolved_level & 1) != 0)
+      r2.origin.x += cursor_glyph->pixel_width - r2.size.width;
+
+    switch (cursor_type)
+      {
+      case DEFAULT_CURSOR:
+      case NO_CURSOR:
+        /* Make the layer invisible. */
+        cursor_layer.opacity = 0.0;
+        cursor_layer.backgroundColor = nil;
+        cursor_layer.frame = r2;
+        break;
+      case FILLED_BOX_CURSOR:
+      case HOLLOW_BOX_CURSOR:
+      case HBAR_CURSOR:
+      case BAR_CURSOR:
+        [CATransaction begin];
+        [CATransaction setAnimationDuration:ns_get_cursor_animation_duration ()];
+        [CATransaction setCompletionBlock:^{
+              cursor_layer.backgroundColor = nil; /* hide after animation */
+              cursor_layer.opacity = 0.0;
+        }];
+        cursor_layer.backgroundColor = FRAME_CURSOR_COLOR (f).CGColor;
+        cursor_layer.opacity = 1.0;
+        cursor_layer.frame = r2;
+        [CATransaction commit];
+        break;
     }
-  cursor_layer.frame = r;
-  [CATransaction commit];
+  }
+  /* Below is the original Emacs drawing code for the cursor. */
+
+  ns_focus (f, NULL, 0);
+
+  NSGraphicsContext *ctx = [NSGraphicsContext currentContext];
+  [ctx saveGraphicsState];
+#ifdef NS_IMPL_GNUSTEP
+  GSRectClipList (ctx, &r, 1);
+#else
+  NSRectClip (r);
+#endif
+
+  [FRAME_CURSOR_COLOR (f) set];
+
+  switch (cursor_type)
+    {
+    case DEFAULT_CURSOR:
+    case NO_CURSOR:
+      break;
+    case FILLED_BOX_CURSOR:
+      /* The call to draw_phys_cursor_glyph can end up undoing the
+	 ns_focus, so unfocus here and regain focus later.  */
+      [ctx restoreGraphicsState];
+      ns_unfocus (f);
+      draw_phys_cursor_glyph (w, glyph_row, DRAW_CURSOR);
+      ns_focus (f, &r, 1);
+      break;
+    case HOLLOW_BOX_CURSOR:
+      /* This works like it does in PostScript, not X Windows.  */
+      [NSBezierPath strokeRect: NSInsetRect (r, 0.5, 0.5)];
+      [ctx restoreGraphicsState];
+      break;
+    case HBAR_CURSOR:
+    case BAR_CURSOR:
+      NSRectFill (r);
+      [ctx restoreGraphicsState];
+      break;
+    }
+
+  ns_unfocus (f);
 }
 
 
@@ -9227,6 +9292,7 @@ ns_in_echo_area (void)
       view->cursor_layer = [CALayer layer];
       [canvasView.layer addSublayer: view->cursor_layer];
       view->cursor_layer.frame = CGRectMake(0, 0, 0, 0);
+
 
 #if !defined (NS_IMPL_COCOA) || MAC_OS_X_VERSION_MIN_REQUIRED <= 1090
 #if MAC_OS_X_VERSION_MAX_ALLOWED > 1090


### PR DESCRIPTION
Thanks for the smooth cursor function! This PR adds support to more cursor styles. It also makes the patch add-only, so that it would be easier to maintain the patch to follow the upstream changes.

By the way, would you mind if I submit the smooth cursor function as a patch to the awesome https://github.com/d12frosted/homebrew-emacs-plus repo? I use this repo to build my daily emacs and I have already created a patch ready to open a PR. (https://github.com/d12frosted/homebrew-emacs-plus/compare/master...mkvoya:homebrew-emacs-plus:smooth-cursor?expand=1)